### PR TITLE
FGTS-56: Make player exit swing state when they collide with something

### DIFF
--- a/godotproject/Player.gd
+++ b/godotproject/Player.gd
@@ -131,9 +131,9 @@ func do_movement(delta):
 		velocity = Vector2.DOWN.rotated(swing_angle) * swing_angular_speed * swing_radius
 		var collision_info = move_and_collide(velocity * delta)
 		if collision_info:
-			print_debug('Collide while swinging with ', collision_info.collider.name)
-			swing_angular_speed *= -0.95
-			# TODO: ^^^ Add some dampening since not every collision is perfectly elastic
+			# We decided that the frog should exit swinging state when they hit a wall or the ground
+			# Let's just make them stop swinging no matter what they collided with
+			stop_swing()
 	else:
 		# Set X velocity based on user input
 		# TODO: maybe do this differently? give the frog a little X momentum?


### PR DESCRIPTION
This should implement feature FGTS-56 where the user exits swinging when they collide with something. This will stop them from bouncing off the ground when they swing into it, and combined with the updated tongue swing jump-off mechanics, should stop them from scaling walls (maybe...)