### PR TITLE
Add HTML5 export preset

### DIFF
--- a/export_procedure.md
+++ b/export_procedure.md
@@ -1,0 +1,15 @@
+# Exporting FGTS to HTML5
+
+The FGTS game can be exported to HTML5 by following these steps:
+1. Ensure you have the `FrogGoesToSpace.github.io` **repository** (henceforth, Github Pages repo) cloned and up-to-date.
+1. In the Github Pages repo, delete all files under the `godotproject-export` directory.
+1. Get latest files in `frogGoesToSpace` repository. (`git checkout main && git pull`)
+1. Open project in Godot
+1. Go Project -> Export...
+1. Select the HTML5 preset and click "Export Project"
+1. Navigate to the now-empty `godotproject-export` subdirectory in the Github Pages repo, and name the file `game.html`.
+1. Click Save.
+    - This will export the Godot project to HTML5
+1. In the Github Pages repo, do `git add godotproject-export` to pick up the new files.
+1. Commit and push the new changes in the Github Pages Repo.
+1. The webpage should update and the latest version should be live! (it may take a minute)

--- a/godotproject/.gitignore
+++ b/godotproject/.gitignore
@@ -2,7 +2,6 @@
 # Godot-specific ignores
 .import/
 export.cfg
-export_presets.cfg
 
 # Imported translations (automatically generated from CSV files)
 *.translation

--- a/godotproject/export_presets.cfg
+++ b/godotproject/export_presets.cfg
@@ -40,3 +40,26 @@ application/product_name=""
 application/file_description=""
 application/copyright=""
 application/trademarks=""
+
+[preset.1]
+
+name="HTML5"
+platform="HTML5"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="../../FrogGoesToSpace.github.io/godotproject-export/game.html"
+patch_list=PoolStringArray(  )
+script_export_mode=1
+script_encryption_key=""
+
+[preset.1.options]
+
+vram_texture_compression/for_desktop=true
+vram_texture_compression/for_mobile=false
+html/custom_html_shell=""
+html/head_include=""
+custom_template/release=""
+custom_template/debug=""

--- a/godotproject/project.godot
+++ b/godotproject/project.godot
@@ -19,6 +19,10 @@ config/name="Frog Goes To Space - Cooper Prototype"
 run/main_scene="res://Level0.tscn"
 config/icon="res://icon.png"
 
+[audio]
+
+output_latency.web=20
+
 [display]
 
 window/size/width=640


### PR DESCRIPTION
This preset allows us to export the game to HTML5 for the purposes of publishing to https://froggoestospace.github.io/