### PR TITLE
Adjust frog tongue

### DIFF
--- a/godotproject/Level0.tscn
+++ b/godotproject/Level0.tscn
@@ -23,7 +23,6 @@ Star = ExtResource( 9 )
 
 [node name="Player" parent="." instance=ExtResource( 1 )]
 position = Vector2( 110.163, 870.544 )
-scale = Vector2( 0.6, 0.6 )
 collision_layer = 34
 collision_mask = 17
 

--- a/godotproject/Player.gd
+++ b/godotproject/Player.gd
@@ -38,7 +38,7 @@ export (float) var tongue_exit_jump_multiplier_in_dirn = 1.1
 export (float) var tongue_exit_jump_bonus_speed_in_dirn = 20
 # This is a constant velocity that will be added in the "up" direction
 # when jumping out of the swing.
-export (float) var tongue_exit_jump_bonus_speed_up = 200
+export (float) var tongue_exit_jump_bonus_speed_up = 300
 
 
 onready var animation_tree = get_node("AnimationTree")
@@ -222,19 +222,15 @@ func handle_normal_horizontal_movement(delta):
 				velocity.x = sign(velocity.x) * min(abs(velocity.x), air_speed_limit)
 
 func _draw():
-	$Line2D.remove_point(1)
-	if tongue_pressed or tongue_held: #if $PlayerTongue.swinging:
-		
-		if$PlayerTongue.swinging:
-			$Line2D.remove_point(1)
-		else:
-			$Line2D.add_point(transform.xform_inv($Position2D.global_position + facing * 400), 1)
-	if $PlayerTongue.swinging:
-		$Line2D.remove_point(1)
-		#draw_line(Vector2(0,0), Vector2(0,0)+get_global_transform().xform_inv(swing_pivot_position), Color(1,0,0))
-		$Line2D.add_point(transform.xform_inv($SwingPos.global_position)+get_global_transform().xform_inv(swing_pivot_position), 1)
-		#$Line2D.add_point(transform.xform_inv($SwingPos.global_position  + facing * swing_pivot_position), 1)
+	var tongue_target_global = null
+	if $PlayerTongue.shooting:
+		tongue_target_global = $PlayerTongue.global_position
+	elif $PlayerTongue.swinging:
+		tongue_target_global = swing_pivot_position
 	
+	$Line2D.remove_point(1)
+	if tongue_target_global != null:
+		$Line2D.add_point(get_global_transform().xform_inv(tongue_target_global), 1)
 
 func do_movement(delta):
 	if $PlayerTongue.swinging:

--- a/godotproject/Player.gd
+++ b/godotproject/Player.gd
@@ -38,7 +38,7 @@ export (float) var tongue_exit_jump_multiplier_in_dirn = 1.1
 export (float) var tongue_exit_jump_bonus_speed_in_dirn = 20
 # This is a constant velocity that will be added in the "up" direction
 # when jumping out of the swing.
-export (float) var tongue_exit_jump_bonus_speed_up = 300
+export (float) var tongue_exit_jump_bonus_speed_up = 200
 
 
 onready var animation_tree = get_node("AnimationTree")

--- a/godotproject/Player.tscn
+++ b/godotproject/Player.tscn
@@ -7,9 +7,8 @@
 [ext_resource path="res://sfx/hop.wav" type="AudioStream" id=5]
 [ext_resource path="res://sfx/collectstarpiece.wav" type="AudioStream" id=6]
 
-[sub_resource type="CapsuleShape2D" id=1]
-radius = 12.279
-height = 9.74179
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 11.696, 15 )
 
 [sub_resource type="AudioStreamRandomPitch" id=2]
 audio_stream = ExtResource( 5 )
@@ -398,18 +397,19 @@ collision_layer = 2
 script = ExtResource( 1 )
 
 [node name="Sprite" type="Sprite" parent="."]
-position = Vector2( 2.52992, 6.36629 )
+position = Vector2( 0.446458, -7.12662 )
 texture = ExtResource( 2 )
 vframes = 6
 hframes = 5
+frame = 2
 
 [node name="Collision" type="CollisionShape2D" parent="."]
-position = Vector2( -2.01278, 14.4265 )
+position = Vector2( -4.54944, 1.15327 )
 rotation = 1.5708
 shape = SubResource( 1 )
 
 [node name="PlayerTongue" parent="." instance=ExtResource( 3 )]
-position = Vector2( 12.2329, 15.5797 )
+position = Vector2( 2.73517, 0.182755 )
 
 [node name="HopSoundPlayer" type="AudioStreamPlayer2D" parent="."]
 stream = SubResource( 2 )
@@ -456,15 +456,8 @@ parameters/swing/blend_position = Vector2( 0, 0 )
 parameters/tongue_launch/blend_position = Vector2( 0, 0 )
 parameters/tongue_retract/blend_position = Vector2( 0, 0 )
 
-[node name="Position2D" type="Position2D" parent="."]
-position = Vector2( 0.660875, 15.8131 )
-
-[node name="SwingPos" type="Position2D" parent="."]
-position = Vector2( 12.5368, -0.573662 )
-
 [node name="Line2D" type="Line2D" parent="."]
-position = Vector2( -23.8093, -2.85048 )
-points = PoolVector2Array( 24.1654, 17.9698, 312.552, 18.1135 )
+points = PoolVector2Array( 0, 0, 15, 0 )
 width = 2.0
 default_color = Color( 0.301961, 0.133333, 0.133333, 1 )
 end_cap_mode = 2

--- a/godotproject/PlayerTongue.gd
+++ b/godotproject/PlayerTongue.gd
@@ -2,9 +2,10 @@ extends Node2D
 
 signal tongue_swing
 
-export (float) var shoot_speed = 1500
-export (float) var max_shoot_dist = 400
-export (float) var max_swing_dist = 100
+# We removed the 0.6 scale on the frog,
+# so we divide by 0.6 here to compensate.
+export (float) var shoot_speed = 1500 * 0.6
+export (float) var max_shoot_dist = 400 * 0.6
 
 var shoot_direction = Vector2.RIGHT
 var idle = true


### PR DESCRIPTION
The code that draws the tongue line was changed to better track the state and position of the PlayerTongue node.

The player scale was changed from 0.6 to 1.0 to make the tongue display properly w.r.t. its actual functionality.

The frog's sprite and hitbox were moved to correspond with the PlayerTongue code which assumes the frog's mouth opens at (0,0).