### PR TITLE
Fix level boundaries

### DIFF
--- a/godotproject/Level0.tscn
+++ b/godotproject/Level0.tscn
@@ -32,7 +32,7 @@ script = ExtResource( 3 )
 right_bound = 10000.0
 bottom_bound = 1000.0
 margin = 10.0
-camera_nodepath = NodePath("../../Level_0/Player/Camera2D")
+player_nodepath = NodePath("../Player")
 
 [node name="DeathPlane" type="Area2D" parent="."]
 script = ExtResource( 4 )

--- a/godotproject/LevelBoundaries.gd
+++ b/godotproject/LevelBoundaries.gd
@@ -5,12 +5,17 @@ export (float) var top_bound;
 export (float) var right_bound;
 export (float) var bottom_bound;
 export (float) var margin;
-export (NodePath) var camera_nodepath;
+export (NodePath) var player_nodepath;
+
+# Make it so that the player doesn't hit against a floor when
+# they fall into a bottomless pit
+const fall_off_screen_amount := 300
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	# Get camera node
-	var camera = get_node(camera_nodepath)
+	# Get camera node off of player
+	var player = get_node(player_nodepath)
+	var camera = player.get_node("Camera2D")
 	# Set camera limit
 	camera.limit_top = top_bound
 	camera.limit_bottom = bottom_bound
@@ -23,10 +28,10 @@ func _ready():
 	# Create 4x StaticBody with CollisionShape
 	var extents = [
 		# x, y, w, h
-		[left_bound, top_bound, margin, bounds_height],
+		[left_bound, top_bound, margin, bounds_height + fall_off_screen_amount],
 		[left_bound, top_bound, bounds_width, margin],
-		[right_bound, bottom_bound, margin, bounds_height],
-		[right_bound, bottom_bound, bounds_width, margin],
+		[right_bound, bottom_bound, margin, bounds_height + fall_off_screen_amount],
+		[right_bound, bottom_bound + fall_off_screen_amount, bounds_width, margin],
 	]
 	for extent in extents:
 		var sb = StaticBody2D.new()


### PR DESCRIPTION
The level boundaries script was coded when we could easily get the path
to the camera in the editor. Now that it is buried in the player scene,
we need to take the path to the player, and then go into the player to
get the camera.

An extra space between the camera limit and the bottom ground was added,
to avoid having the player stop mid-air at the bottom of a bottomless
pit. Now they fall offscreen.