### PR TITLE
Reduce ResourceQueue from multithread to single

### DIFF
--- a/godotproject/Global/Global.tscn
+++ b/godotproject/Global/Global.tscn
@@ -222,9 +222,54 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2, 0.3, 0.4, 0.5 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.175, 0.2, 0.225, 0.25, 0.275, 0.3, 0.325, 0.35, 0.375, 0.4, 0.425, 0.45, 0.475, 0.5 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
 "values": [ {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
+"args": [  ],
+"method": "_process_loading"
+}, {
 "args": [  ],
 "method": "_process_loading"
 }, {
@@ -304,7 +349,7 @@ transitions = [ "loading_fadein_out", "swipe_out", SubResource( 12 ), "idle", "s
 [node name="Node" type="Node"]
 pause_mode = 2
 script = ExtResource( 1 )
-game_audio_volume_fadeout = 0.0
+game_audio_volume_fadeout = 1.0
 
 [node name="DebugModeTextLayer" type="CanvasLayer" parent="."]
 layer = 100
@@ -326,7 +371,7 @@ layer = 10
 
 [node name="SideSwipeAnimationPoly" type="Polygon2D" parent="SideSwipeAnimationLayer"]
 color = Color( 0, 0, 0, 1 )
-polygon = PoolVector2Array( 0, 0, -100, 512, 800, 512, 800, 0 )
+polygon = PoolVector2Array( 740, 0, 640, 512, 800, 512, 800, 0 )
 
 [node name="LoadingText" type="Label" parent="SideSwipeAnimationLayer"]
 self_modulate = Color( 0, 0, 0, 0 )

--- a/godotproject/Global/ResourceQueue.gd.multithread
+++ b/godotproject/Global/ResourceQueue.gd.multithread
@@ -3,9 +3,11 @@
 # "Note: this code, in its current form, is not tested in real world scenarios. If you run into any issues, ask for help in one of Godot's community channels."
 # The Godot documentation is under the CC-BY 3.0 license: https://creativecommons.org/licenses/by/3.0/
 # 2020-01-14: File included verbatim from https://docs.godotengine.org/en/stable/_downloads/db6ccb8924e9f1d36c1319e2813e4808/resource_queue.gd except for this header.
-# 2020-02-02: Modified to be single-threaded
-
+var thread
 var mutex
+var sem
+
+var time_max = 100 # Milliseconds.
 
 var queue = []
 var pending = {}
@@ -13,8 +15,18 @@ var pending = {}
 func _lock(_caller):
 	mutex.lock()
 
+
 func _unlock(_caller):
 	mutex.unlock()
+
+
+func _post(_caller):
+	sem.post()
+
+
+func _wait(_caller):
+	sem.wait()
+
 
 func queue_resource(path, p_in_front = false):
 	_lock("queue_resource")
@@ -34,6 +46,7 @@ func queue_resource(path, p_in_front = false):
 		else:
 			queue.push_back(res)
 		pending[path] = res
+		_post("queue_resource")
 		_unlock("queue_resource")
 		return
 
@@ -58,23 +71,8 @@ func get_progress(path):
 	_unlock("get_progress")
 	return ret
 
-func _step():
-	_lock("step")
-	if queue.size() > 0:
-		var res = queue[0]
-		var ret = res.poll()
-		if ret == ERR_FILE_EOF || ret != OK:
-			var path = res.get_meta("path")
-			if path in pending: # Else, it was already retrieved.
-				pending[res.get_meta("path")] = res.get_resource()
-			# Something might have been put at the front of the queue while
-			# we polled, so use erase instead of remove.
-			queue.erase(res)
-	_unlock("step")
 
 func is_ready(path):
-	# Step our loading
-	_step()
 	var ret
 	_lock("is_ready")
 	if path in pending:
@@ -86,9 +84,15 @@ func is_ready(path):
 
 
 func _wait_for_resource(res, path):
-	while !is_ready(path):
-		_step()
-	return pending[path]
+	_unlock("wait_for_resource")
+	while true:
+		VisualServer.sync()
+		OS.delay_usec(16000) # Wait approximately 1 frame.
+		_lock("wait_for_resource")
+		if queue.size() == 0 || queue[0] != res:
+			return pending[path]
+		_unlock("wait_for_resource")
+
 
 func get_resource(path):
 	_lock("get_resource")
@@ -113,5 +117,34 @@ func get_resource(path):
 		_unlock("return")
 		return ResourceLoader.load(path)
 
+
+func thread_process():
+	_wait("thread_process")
+	_lock("process")
+
+	while queue.size() > 0:
+		var res = queue[0]
+		_unlock("process_poll")
+		var ret = res.poll()
+		_lock("process_check_queue")
+
+		if ret == ERR_FILE_EOF || ret != OK:
+			var path = res.get_meta("path")
+			if path in pending: # Else, it was already retrieved.
+				pending[res.get_meta("path")] = res.get_resource()
+			# Something might have been put at the front of the queue while
+			# we polled, so use erase instead of remove.
+			queue.erase(res)
+	_unlock("process")
+
+
+func thread_func(_u):
+	while true:
+		thread_process()
+
+
 func start():
 	mutex = Mutex.new()
+	sem = Semaphore.new()
+	thread = Thread.new()
+	thread.start(self, "thread_func", 0)

--- a/godotproject/Menus/MainMenu/MainMenu.tscn
+++ b/godotproject/Menus/MainMenu/MainMenu.tscn
@@ -62,9 +62,9 @@ __meta__ = {
 }
 
 [node name="Label3" type="Label" parent="CenterContainer/VBoxContainer"]
-margin_top = 220.0
+margin_top = 221.0
 margin_right = 362.0
-margin_bottom = 280.0
+margin_bottom = 281.0
 rect_min_size = Vector2( 0, 60 )
 theme = ExtResource( 1 )
 custom_fonts/font = SubResource( 2 )


### PR DESCRIPTION
This allows HTML5 to work

The polling rate in the animation tree has also been jacked way up to
compensate for the fact that we only load when we poll the ResourceQueue