### PR TITLE
FGTS-153: checkpoints

### DIFF
--- a/godotproject/DeathPlane.gd
+++ b/godotproject/DeathPlane.gd
@@ -1,16 +1,5 @@
 extends Area2D
 
-
-export (Vector2) var start_postion
-
-
-var level_name = null
-
 func _on_DeathPlane_body_entered(body):
-	if  body.name == "Player":
-		body.takeDamage(1)
-		# Check if the player's dead after they take damage
-		# If not, play the animation of them being moved to safe ground
-		if !body.dead:
-			Global.fade_set_body_to_position(body, start_postion)
-
+	if Global.is_player(body):
+		body.hit_death_plane()

--- a/godotproject/Global/Global.gd
+++ b/godotproject/Global/Global.gd
@@ -185,3 +185,8 @@ func format_time(time):
 	var seconds = int(time) % 60
 	var subseconds = int(time * 60) % 60
 	return "%01d:%02d:%02d" % [minutes, seconds, subseconds]
+
+# Check if a given body is the player. Useful for scripts where
+# we only want to interact with the player.
+func is_player(body):
+	return body.name == "Player"

--- a/godotproject/Global/ResourceQueue.gd
+++ b/godotproject/Global/ResourceQueue.gd
@@ -85,7 +85,7 @@ func is_ready(path):
 	return ret
 
 
-func _wait_for_resource(res, path):
+func _wait_for_resource(_res, path):
 	while !is_ready(path):
 		_step()
 	return pending[path]

--- a/godotproject/Level0.tscn
+++ b/godotproject/Level0.tscn
@@ -15,6 +15,7 @@
 [ext_resource path="res://EOL.tscn" type="PackedScene" id=13]
 [ext_resource path="res://sfx/Level0-Theme.ogg" type="AudioStream" id=14]
 [ext_resource path="res://TextTip.tscn" type="PackedScene" id=17]
+[ext_resource path="res://RespawnPositionArea.tscn" type="PackedScene" id=15]
 
 [node name="Level_0" type="Node2D"]
 script = ExtResource( 12 )
@@ -34,7 +35,6 @@ margin = 10.0
 player_nodepath = NodePath("../Player")
 
 [node name="DeathPlane" parent="." instance=ExtResource( 4 )]
-start_postion = Vector2( 121, 896 )
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = ExtResource( 2 )
@@ -144,3 +144,10 @@ text = "[center] press shift/x while swinging to [wave] launch [/wave] yourself 
 [node name="TextTip4" parent="." instance=ExtResource( 17 )]
 position = Vector2( 2587.93, 661.872 )
 text = "[center] you can control the direction of your tongue: try shooting [wave] diagonally"
+[node name="RespawnPositionArea" parent="." instance=ExtResource( 15 )]
+position = Vector2( 276, 884 )
+scale = Vector2( 2.52, 1 )
+
+[node name="RespawnPositionArea2" parent="." instance=ExtResource( 15 )]
+position = Vector2( 8752, 520 )
+scale = Vector2( 3, 1 )

--- a/godotproject/Level0.tscn
+++ b/godotproject/Level0.tscn
@@ -35,6 +35,7 @@ margin = 10.0
 player_nodepath = NodePath("../Player")
 
 [node name="DeathPlane" parent="." instance=ExtResource( 4 )]
+position = Vector2( 0, 48 )
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = ExtResource( 2 )
@@ -149,5 +150,9 @@ position = Vector2( 276, 884 )
 scale = Vector2( 2.52, 1 )
 
 [node name="RespawnPositionArea2" parent="." instance=ExtResource( 15 )]
-position = Vector2( 8752, 520 )
+position = Vector2( 9112, 560 )
 scale = Vector2( 3, 1 )
+
+[node name="RespawnPositionArea3" parent="." instance=ExtResource( 15 )]
+position = Vector2( 9832, 560 )
+scale = Vector2( 2, 1 )

--- a/godotproject/Level1.tscn
+++ b/godotproject/Level1.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=25 format=2]
 
 [ext_resource path="res://Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Level1.tres" type="TileSet" id=2]
@@ -21,6 +21,7 @@
 [ext_resource path="res://Tiles/Objects/nasaSign.png" type="Texture" id=19]
 [ext_resource path="res://Bird.tscn" type="PackedScene" id=20]
 [ext_resource path="res://enemy-Ant.tscn" type="PackedScene" id=21]
+[ext_resource path="res://RespawnPositionArea.tscn" type="PackedScene" id=22]
 
 [sub_resource type="TileSet" id=1]
 0/name = "toxic_waste"
@@ -354,7 +355,6 @@ player_nodepath = NodePath("../Player")
 
 [node name="DeathPlane" parent="." instance=ExtResource( 9 )]
 position = Vector2( -56, -680 )
-start_postion = Vector2( 121, 264 )
 
 [node name="Fan" parent="." instance=ExtResource( 14 )]
 position = Vector2( 800, 216 )
@@ -489,3 +489,46 @@ position = Vector2( 8248, -1440 )
 
 [node name="enemy-Ant13" parent="." instance=ExtResource( 21 )]
 position = Vector2( 6504, -1328 )
+
+[node name="RespawnPositionArea" parent="." instance=ExtResource( 22 )]
+position = Vector2( 1136, -136 )
+
+[node name="RespawnPositionArea2" parent="." instance=ExtResource( 22 )]
+position = Vector2( 1240, 232 )
+
+[node name="RespawnPositionArea3" parent="." instance=ExtResource( 22 )]
+position = Vector2( 2264, -336 )
+
+[node name="RespawnPositionArea4" parent="." instance=ExtResource( 22 )]
+position = Vector2( 2352, -688 )
+
+[node name="RespawnPositionArea5" parent="." instance=ExtResource( 22 )]
+position = Vector2( 1520, -272 )
+
+[node name="RespawnPositionArea6" parent="." instance=ExtResource( 22 )]
+position = Vector2( 2984, -696 )
+
+[node name="RespawnPositionArea7" parent="." instance=ExtResource( 22 )]
+position = Vector2( 3352, -696 )
+
+[node name="RespawnPositionArea8" parent="." instance=ExtResource( 22 )]
+position = Vector2( 2816, -232 )
+
+[node name="RespawnPositionArea9" parent="." instance=ExtResource( 22 )]
+position = Vector2( 3232, -232 )
+
+[node name="RespawnPositionArea10" parent="." instance=ExtResource( 22 )]
+position = Vector2( 3984, -632 )
+scale = Vector2( 1.2, 1 )
+
+[node name="RespawnPositionArea11" parent="." instance=ExtResource( 22 )]
+position = Vector2( 4376, -408 )
+
+[node name="RespawnPositionArea12" parent="." instance=ExtResource( 22 )]
+position = Vector2( 4968, -1280 )
+
+[node name="RespawnPositionArea13" parent="." instance=ExtResource( 22 )]
+position = Vector2( 6520, -400 )
+
+[node name="RespawnPositionArea14" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7152, -376 )

--- a/godotproject/Level1.tscn
+++ b/godotproject/Level1.tscn
@@ -354,7 +354,7 @@ margin = 10.0
 player_nodepath = NodePath("../Player")
 
 [node name="DeathPlane" parent="." instance=ExtResource( 9 )]
-position = Vector2( -56, -680 )
+position = Vector2( -64, -568 )
 
 [node name="Fan" parent="." instance=ExtResource( 14 )]
 position = Vector2( 800, 216 )
@@ -491,68 +491,90 @@ position = Vector2( 8248, -1440 )
 position = Vector2( 6504, -1328 )
 
 [node name="RespawnPositionArea" parent="." instance=ExtResource( 22 )]
-position = Vector2( 1136, -136 )
+position = Vector2( 1216, -96 )
 
-[node name="RespawnPositionArea3" parent="." instance=ExtResource( 22 )]
-position = Vector2( 2264, -336 )
+[node name="RespawnPositionArea2" parent="." instance=ExtResource( 22 )]
+position = Vector2( 144, 264 )
 
 [node name="RespawnPositionArea4" parent="." instance=ExtResource( 22 )]
-position = Vector2( 2352, -688 )
+position = Vector2( 2464, -656 )
 
 [node name="RespawnPositionArea5" parent="." instance=ExtResource( 22 )]
-position = Vector2( 1520, -272 )
+position = Vector2( 1424, -240 )
 
 [node name="RespawnPositionArea6" parent="." instance=ExtResource( 22 )]
-position = Vector2( 2984, -696 )
+position = Vector2( 2912, -656 )
 
 [node name="RespawnPositionArea7" parent="." instance=ExtResource( 22 )]
-position = Vector2( 3352, -696 )
+position = Vector2( 3424, -656 )
 
 [node name="RespawnPositionArea8" parent="." instance=ExtResource( 22 )]
-position = Vector2( 2816, -232 )
+position = Vector2( 2752, -192 )
 
 [node name="RespawnPositionArea9" parent="." instance=ExtResource( 22 )]
-position = Vector2( 3232, -232 )
+position = Vector2( 3296, -192 )
 
 [node name="RespawnPositionArea10" parent="." instance=ExtResource( 22 )]
-position = Vector2( 3984, -632 )
-scale = Vector2( 1.2, 1 )
+position = Vector2( 3864, -592 )
+scale = Vector2( 0.5, 1 )
+
+[node name="RespawnPositionArea23" parent="." instance=ExtResource( 22 )]
+position = Vector2( 4104, -592 )
+scale = Vector2( 0.5, 1 )
 
 [node name="RespawnPositionArea11" parent="." instance=ExtResource( 22 )]
-position = Vector2( 4376, -408 )
+position = Vector2( 4304, -368 )
 
 [node name="RespawnPositionArea12" parent="." instance=ExtResource( 22 )]
-position = Vector2( 4968, -1280 )
+position = Vector2( 4864, -1264 )
+
+[node name="RespawnPositionArea24" parent="." instance=ExtResource( 22 )]
+position = Vector2( 5120, -1264 )
 
 [node name="RespawnPositionArea13" parent="." instance=ExtResource( 22 )]
-position = Vector2( 6520, -400 )
+position = Vector2( 6616, -368 )
 
 [node name="RespawnPositionArea14" parent="." instance=ExtResource( 22 )]
-position = Vector2( 7152, -376 )
+position = Vector2( 7032, -368 )
+scale = Vector2( 0.5, 1 )
+
+[node name="RespawnPositionArea25" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7272, -368 )
+scale = Vector2( 0.5, 1 )
 
 [node name="RespawnPositionArea15" parent="." instance=ExtResource( 22 )]
-position = Vector2( 7784, -384 )
+position = Vector2( 7672, -368 )
+scale = Vector2( 0.5, 1 )
+
+[node name="RespawnPositionArea26" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7896, -368 )
+scale = Vector2( 0.5, 1 )
 
 [node name="RespawnPositionArea19" parent="." instance=ExtResource( 22 )]
-position = Vector2( 7176, -1296 )
+position = Vector2( 7264, -1264 )
 
 [node name="RespawnPositionArea20" parent="." instance=ExtResource( 22 )]
-position = Vector2( 7784, -1288 )
+position = Vector2( 7696, -1264 )
 
 [node name="RespawnPositionArea21" parent="." instance=ExtResource( 22 )]
-position = Vector2( 8984, -1296 )
+position = Vector2( 9072, -1264 )
 
 [node name="RespawnPositionArea22" parent="." instance=ExtResource( 22 )]
-position = Vector2( 9728, -1296 )
+position = Vector2( 9624, -1264 )
+
+[node name="RespawnPositionArea28" parent="." instance=ExtResource( 22 )]
+position = Vector2( 10272, -720 )
 
 [node name="RespawnPositionArea17" parent="." instance=ExtResource( 22 )]
-position = Vector2( 7784, -1008 )
+position = Vector2( 7784, -976 )
 scale = Vector2( 0.4, 1 )
 
 [node name="RespawnPositionArea18" parent="." instance=ExtResource( 22 )]
-position = Vector2( 7144, -1000 )
+position = Vector2( 7144, -976 )
 scale = Vector2( 0.4, 1 )
 
 [node name="RespawnPositionArea16" parent="." instance=ExtResource( 22 )]
-position = Vector2( 8464, -392 )
-scale = Vector2( 1.5, 1 )
+position = Vector2( 8312, -368 )
+
+[node name="RespawnPositionArea27" parent="." instance=ExtResource( 22 )]
+position = Vector2( 8640, -368 )

--- a/godotproject/Level1.tscn
+++ b/godotproject/Level1.tscn
@@ -493,9 +493,6 @@ position = Vector2( 6504, -1328 )
 [node name="RespawnPositionArea" parent="." instance=ExtResource( 22 )]
 position = Vector2( 1136, -136 )
 
-[node name="RespawnPositionArea2" parent="." instance=ExtResource( 22 )]
-position = Vector2( 1240, 232 )
-
 [node name="RespawnPositionArea3" parent="." instance=ExtResource( 22 )]
 position = Vector2( 2264, -336 )
 
@@ -532,3 +529,30 @@ position = Vector2( 6520, -400 )
 
 [node name="RespawnPositionArea14" parent="." instance=ExtResource( 22 )]
 position = Vector2( 7152, -376 )
+
+[node name="RespawnPositionArea15" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7784, -384 )
+
+[node name="RespawnPositionArea19" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7176, -1296 )
+
+[node name="RespawnPositionArea20" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7784, -1288 )
+
+[node name="RespawnPositionArea21" parent="." instance=ExtResource( 22 )]
+position = Vector2( 8984, -1296 )
+
+[node name="RespawnPositionArea22" parent="." instance=ExtResource( 22 )]
+position = Vector2( 9728, -1296 )
+
+[node name="RespawnPositionArea17" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7784, -1008 )
+scale = Vector2( 0.4, 1 )
+
+[node name="RespawnPositionArea18" parent="." instance=ExtResource( 22 )]
+position = Vector2( 7144, -1000 )
+scale = Vector2( 0.4, 1 )
+
+[node name="RespawnPositionArea16" parent="." instance=ExtResource( 22 )]
+position = Vector2( 8464, -392 )
+scale = Vector2( 1.5, 1 )

--- a/godotproject/Player.tscn
+++ b/godotproject/Player.tscn
@@ -560,12 +560,15 @@ position = Vector2( 2.73517, 0.182755 )
 
 [node name="HopSoundPlayer" type="AudioStreamPlayer2D" parent="."]
 stream = SubResource( 2 )
+bus = "Sfx"
 
 [node name="JumpSoundPlayer" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 4 )
+bus = "Sfx"
 
 [node name="CollectStarPieceSoundPlayer" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 6 )
+bus = "Sfx"
 
 [node name="InvulnerableTimer" type="Timer" parent="."]
 one_shot = true

--- a/godotproject/RespawnPositionArea.gd
+++ b/godotproject/RespawnPositionArea.gd
@@ -12,7 +12,8 @@ func _process(_delta):
 	# We use the overlaps_body function to double-check
 	# that the player is still inside of us.
 	if player and overlaps_body(player):
-		player.update_respawn_position()
+		# Tell the player where the center of this respawn marker is
+		player.update_respawn_position(get_global_transform().xform(Vector2.ZERO))
 	else:
 		# If the player somehow exited without the event,
 		# then we mark them as not inside.

--- a/godotproject/RespawnPositionArea.gd
+++ b/godotproject/RespawnPositionArea.gd
@@ -1,0 +1,30 @@
+extends Area2D
+
+# We keep track of whether or not the player could
+# currently be inside our collision, based on the
+# entered/exited events.
+var player_inside := false
+var player = null
+
+func _process(_delta):
+	if !player_inside:
+		return
+	# We use the overlaps_body function to double-check
+	# that the player is still inside of us.
+	if player and overlaps_body(player):
+		player.update_respawn_position()
+	else:
+		# If the player somehow exited without the event,
+		# then we mark them as not inside.
+		player_inside = false
+
+func _on_RespawnPositionArea_body_entered(body):
+	if !Global.is_player(body):
+		return
+	player = body
+	player_inside = true
+
+func _on_RespawnPositionArea_body_exited(body):
+	if !Global.is_player(body):
+		return
+	player_inside = false

--- a/godotproject/RespawnPositionArea.tscn
+++ b/godotproject/RespawnPositionArea.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://RespawnPositionArea.gd" type="Script" id=1]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 100, 60 )
+
+[node name="RespawnPositionArea" type="Area2D"]
+script = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )
+[connection signal="body_entered" from="." to="." method="_on_RespawnPositionArea_body_entered"]
+[connection signal="body_exited" from="." to="." method="_on_RespawnPositionArea_body_exited"]


### PR DESCRIPTION
This PR adds in checkpoint objects to each level. When the frog is inside a checkpoint object and is on the ground, the position and facing value will be saved, and it will be restored when the frog hits the deathplane. Knockback is still applied, but only in the upward direction. The deathplanes were also moved so that the player falls fully out of frame before playing the hit animation, as I thought it was jarring seeing the first frame of the hurt animation before the fadeout.