### PR TITLE
Stop caching the player and implement better check for global timer (fixes Pi crash)

### DIFF
--- a/godotproject/Global/Global.gd
+++ b/godotproject/Global/Global.gd
@@ -113,7 +113,7 @@ func fade_set_body_to_position(body, position):
 	fade_action = FadeAction.MOVE_POSITION
 	fade_action_body = body
 	fade_action_position = position
-	
+
 	# Fade to loading screen
 	swipe_anim_state_machine.travel('swipe_in')
 
@@ -138,7 +138,7 @@ func _process_loading():
 
 		# Close the high-score screen, if it was open
 		HighScoreScreen.close()
-		
+
 		# Any cutscene that was playing is now over, or will be taken over by the new object.
 		# If you need to adjust these values, make sure you do it in the _enter_tree function.
 		cutscene_pauses_game = false
@@ -190,3 +190,11 @@ func format_time(time):
 # we only want to interact with the player.
 func is_player(body):
 	return body.name == "Player"
+
+# Check if a node exists and is inside the tree. Used to track if we have
+# Based on: https://godotengine.org/qa/37579/need-an-easy-way-to-check-which-ones-are-still-in-the-scene-tree
+func node_exists_in_tree(node):
+	return node != null and \
+		is_instance_valid(node) and \
+		node is Node and \
+		node.is_inside_tree()

--- a/godotproject/Global/HUDRoot.gd
+++ b/godotproject/Global/HUDRoot.gd
@@ -5,7 +5,6 @@ onready var lb_star = $LeftPanel/HBoxContainer/StarContainer/StarCountLabel
 onready var lb_time = $RightPanel/TimeCountLabel
 onready var menu = $"/root/Global/InGameMenuLayer/InGameMenu"
 
-var player = null
 var countup_timer = null
 
 func _process(_delta):
@@ -22,18 +21,17 @@ func _process(_delta):
 		$StyleAnimationPlayer.play("inmenu")
 	else:
 		$StyleAnimationPlayer.play("ingame")
-	if !player:
-		# Get player
-		var scene = get_tree().current_scene
-		if !scene:
-			return
-		player = scene.find_node("Player", false, true)
-	if player:
-		var health = player.health
-		lb_life.text = str(health)
-		var star = player.star_piece_count
-		lb_star.text = str(star)
-	if !countup_timer:
+
+	# Get player from current scene
+	var scene = get_tree().current_scene
+	if scene:
+		var player = scene.find_node("Player", false, true)
+		if player:
+			var health = player.health
+			lb_life.text = str(health)
+			var star = player.star_piece_count
+			lb_star.text = str(star)
+	if !Global.node_exists_in_tree(countup_timer):
 		countup_timer = $"/root/CountupTimer"
 	if countup_timer:
 		var time = countup_timer.time


### PR DESCRIPTION
Caching the player object was leading to some really weird effects,
including crashing on level reloading (which can be fixed using the
`node_exists_in_tree` function), and a weird bug where the health and
star counters showed as Null after finishing the game and starting again

This gets around all of that by just getting the player object every
frame, which is OK because we have CPU time to spare on the Pi.