### PR TITLE
Added Start and End Positions for export. Fix Collision Shape

### DIFF
--- a/godotproject/Objects/Sawblade/SawBlade.gd
+++ b/godotproject/Objects/Sawblade/SawBlade.gd
@@ -26,9 +26,12 @@ enum MOVE_STATE {
 }
 
 func _ready():
+	init()
+
+func init():
 	radius = $PlayerCollision/CollisionShape2D.shape.radius
 	moveState = MOVE_STATE.accelerating_e
-	position = $StartPos.position;	
+	position = $StartPos.position;
 	ideal_velocity = 10
 	totalLength = ($EndPos.position - $StartPos.position).length()
 

--- a/godotproject/Objects/Sawblade/SawBlade.gd
+++ b/godotproject/Objects/Sawblade/SawBlade.gd
@@ -45,13 +45,13 @@ func _physics_process(delta):
 	velocity = move_and_slide(velocity, FLOOR)
 	
 	#rotating the sprite
-	var rotation = velocity.length() / radius * direction
+	var rotation = 5 * (velocity.length() / radius * direction)
 	rotation_degrees = int(rotation_degrees + rotation) % 360
 
 func _calculate_ideal_velocity():
 	# Setting originating and ending positions
-	var original_position = $StartPos.position;
-	var target_position = $EndPos.position;
+	var original_position = $StartPos.position
+	var target_position = $EndPos.position
 	if (direction == -1):
 		original_position = $EndPos.position
 		target_position = $StartPos.position

--- a/godotproject/Objects/Sawblade/SawBladeArea.gd
+++ b/godotproject/Objects/Sawblade/SawBladeArea.gd
@@ -1,0 +1,18 @@
+extends Area2D
+
+const DEFAULT_START = Vector2(-150, 0)
+const DEFAULT_END = Vector2(150, 0)
+
+export var Start: Vector2 = DEFAULT_START
+export var End: Vector2 = DEFAULT_END
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	call_deferred("SetSawPosition")
+	pass # Replace with function body.
+
+func SetSawPosition():
+	get_node("SawBlade/StartPos").position = Start
+	get_node("SawBlade/EndPos").position = End
+	$SawBlade.init()
+

--- a/godotproject/Objects/Sawblade/SawBladeArea.tscn
+++ b/godotproject/Objects/Sawblade/SawBladeArea.tscn
@@ -19,7 +19,9 @@ collision_mask = 256
 script = ExtResource( 4 )
 
 [node name="SawBlade" type="KinematicBody2D" parent="."]
+z_index = -1
 collision_layer = 64
+collision_mask = 0
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="SawBlade"]
@@ -46,9 +48,9 @@ position = Vector2( 144, 0 )
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="SawBlade"]
 stream = ExtResource( 3 )
-volume_db = -10.0
 autoplay = true
 max_distance = 1000.0
+attenuation = 2.92817
 bus = "Sfx"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/godotproject/Objects/Sawblade/SawBladeArea.tscn
+++ b/godotproject/Objects/Sawblade/SawBladeArea.tscn
@@ -3,6 +3,7 @@
 [ext_resource path="res://Objects/Sawblade/sawblade.png" type="Texture" id=1]
 [ext_resource path="res://Objects/Sawblade/SawBlade.gd" type="Script" id=2]
 [ext_resource path="res://sfx/blade_sfx.wav" type="AudioStream" id=3]
+[ext_resource path="res://Objects/Sawblade/SawBladeArea.gd" type="Script" id=4]
 
 [sub_resource type="CircleShape2D" id=1]
 radius = 30.0
@@ -10,9 +11,12 @@ radius = 30.0
 [sub_resource type="CircleShape2D" id=2]
 radius = 30.0
 
+[sub_resource type="CircleShape2D" id=3]
+
 [node name="SawBladeArea" type="Area2D"]
 collision_layer = 0
 collision_mask = 256
+script = ExtResource( 4 )
 
 [node name="SawBlade" type="KinematicBody2D" parent="."]
 collision_layer = 64
@@ -47,4 +51,6 @@ autoplay = true
 max_distance = 1000.0
 bus = "Sfx"
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 3 )
 [connection signal="body_entered" from="SawBlade/PlayerCollision" to="SawBlade" method="_on_PlayerCollision_body_entered"]


### PR DESCRIPTION
This change does 2 things.
1. Adds start and end saw positions as export variables for easy level editing. 
2. Add Collision Shape to satisfy node hierarchy requirements on KinematicBody2D (no functional change)